### PR TITLE
Added snyk as a blocking step to the build workflow

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -75,6 +75,17 @@ jobs:
       - name: Install cumulus-passthrough-lambda
         run: poetry install
 
+      - name: Run Snyk as a blocking step
+        uses: snyk/actions/python-3.8@master
+        env:
+            SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: test
+          args: >
+              --org=${{ secrets.SNYK_ORG_ID }}
+              --project-name=${{ github.repository }}
+              --severity-threshold=high
+              --fail-on=all
       - name: Run Snyk on Python
         uses: snyk/actions/python-3.8@master
         env:


### PR DESCRIPTION
Github Issue: #Snyk Blocking Step

### Description

This code adds a blocking step to the github actions to stop the build if any fixable vulnerabilities are found

### Overview of work done

One github action added to scan with Snyk 

### Overview of verification done

I've run the build workflow and the step added runs and passes without issue

### Overview of integration done

The change affects only the testing portion of the github action workflow, no functional changes were made

## PR checklist:

* [X] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [X] Integration testing

